### PR TITLE
Add FileManipulation action implementation and documentation

### DIFF
--- a/dist/codx-schema.json
+++ b/dist/codx-schema.json
@@ -37,10 +37,24 @@
             {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/FileSystemActionCopyDataSchema"
+                  "$ref": "#/definitions/FileManipulationActionAppendDataSchema"
                 },
                 {
-                  "$ref": "#/definitions/FileSystemActionCreateDataSchema"
+                  "$ref": "#/definitions/FileManipulationActionCreateDataSchema"
+                },
+                {
+                  "$ref": "#/definitions/FileManipulationActionPrependDataSchema"
+                },
+                {
+                  "$ref": "#/definitions/FileManipulationActionUpdateDataSchema"
+                }
+              ],
+              "description": "FileManipulationActionDataSchema"
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FileSystemActionCopyDataSchema"
                 },
                 {
                   "$ref": "#/definitions/FileSystemActionDeleteDataSchema"
@@ -192,6 +206,121 @@
       "additionalProperties": false,
       "description": "FailActionDataSchema"
     },
+    "FileManipulationActionAppendDataSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "fileManipulation"
+        },
+        "operation": {
+          "type": "string",
+          "const": "append"
+        },
+        "path": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "operation",
+        "path",
+        "content"
+      ],
+      "additionalProperties": false,
+      "description": "FileManipulationActionAppendDataSchema"
+    },
+    "FileManipulationActionCreateDataSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "fileManipulation"
+        },
+        "operation": {
+          "type": "string",
+          "const": "create"
+        },
+        "path": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        },
+        "overwrite": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "type",
+        "operation",
+        "path"
+      ],
+      "additionalProperties": false,
+      "description": "FileManipulationActionCreateDataSchema"
+    },
+    "FileManipulationActionPrependDataSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "fileManipulation"
+        },
+        "operation": {
+          "type": "string",
+          "const": "prepend"
+        },
+        "path": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "operation",
+        "path",
+        "content"
+      ],
+      "additionalProperties": false,
+      "description": "FileManipulationActionPrependDataSchema"
+    },
+    "FileManipulationActionUpdateDataSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "fileManipulation"
+        },
+        "operation": {
+          "type": "string",
+          "const": "update"
+        },
+        "path": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "operation",
+        "path",
+        "pattern",
+        "content"
+      ],
+      "additionalProperties": false,
+      "description": "FileManipulationActionUpdateDataSchema"
+    },
     "FileSystemActionCopyDataSchema": {
       "type": "object",
       "properties": {
@@ -222,36 +351,6 @@
       ],
       "additionalProperties": false,
       "description": "FileSystemActionCopyDataSchema"
-    },
-    "FileSystemActionCreateDataSchema": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "fileSystem"
-        },
-        "operation": {
-          "type": "string",
-          "const": "create"
-        },
-        "path": {
-          "type": "string"
-        },
-        "content": {
-          "type": "string"
-        },
-        "overwrite": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "required": [
-        "type",
-        "operation",
-        "path"
-      ],
-      "additionalProperties": false,
-      "description": "FileSystemActionCreateDataSchema"
     },
     "FileSystemActionDeleteDataSchema": {
       "type": "object",

--- a/docs/en/actions/fail.md
+++ b/docs/en/actions/fail.md
@@ -1,13 +1,14 @@
 # Fail Action
 
-The `fail` action allows you to intentionally raise an error during the execution of a recipe. This action is useful for stopping the execution of a recipe when a specific condition is not met.
+The `fail` action allows you to intentionally raise an error during the execution of a recipe. This action is useful for
+stopping the execution of a recipe when a specific condition is not met.
 
 ## Parameters
 
-| Parameter | Type   | Required | Description                                                                                |
-|-----------|--------|----------|--------------------------------------------------------------------------------------------|
-| `type`    | string | Yes      | Must be `"fail"`                                                                           |
-| `message` | string | No       | The error message to display. Default: "Explicit failure triggered by fail action"         |
+| Parameter | Type   | Required | Description                                                                        |
+|-----------|--------|----------|------------------------------------------------------------------------------------|
+| `type`    | string | Yes      | Must be `"fail"`                                                                   |
+| `message` | string | No       | The error message to display. Default: "Explicit failure triggered by fail action" |
 
 ## Return Value
 
@@ -63,7 +64,8 @@ The `fail` action is particularly useful in combination with `onFailure` blocks 
 
 - **Clear Error Messages**: Provide descriptive error messages that explain why the failure occurred.
 - **Conditional Failures**: Use the `condition` attribute to make failures conditional based on specific criteria.
-- **Error Recovery**: Always provide an `onFailure` block when you want to recover from the error and continue execution.
+- **Error Recovery**: Always provide an `onFailure` block when you want to recover from the error and continue
+  execution.
 
 ## Alternatives
 
@@ -74,4 +76,4 @@ For some scenarios, you might want to consider these alternatives:
 
 [↑ List of Actions](../actions.md)
 
-[← Command](command.md) ─ [FileSystem →](fileSystem.md)
+[← Command](command.md) ─ [FileManipulation →](fileManipulation.md)

--- a/docs/en/actions/fileManipulation.md
+++ b/docs/en/actions/fileManipulation.md
@@ -1,0 +1,278 @@
+# FileManipulation Action
+
+The `fileManipulation` action allows you to create and manipulate file content during the execution of a recipe. This
+action is essential for creating files, adding content to the beginning or end of files, and updating content using
+regular expressions.
+
+## Available Operations
+
+The `fileManipulation` action supports [several operations](#operation-details), each with its own parameters:
+
+1. `append`: [Add content to the end of a file](#append-content-to-a-file)
+2. `create`: [Create a file](#create-a-file)
+3. `prepend`: [Add content to the beginning of a file](#prepend-content-to-a-file)
+4. `update`: [Update content of a file](#update-content-in-a-file)
+
+## Common Parameters
+
+| Parameter   | Type   | Required | Description                                                                |
+|-------------|--------|----------|----------------------------------------------------------------------------|
+| `type`      | string | Yes      | Must be `"fileManipulation"`                                               |
+| `operation` | string | Yes      | The operation to perform (`"create"`, `"prepend"`, `"append"`, `"update"`) |
+
+## Operation Details
+
+### Append Content to a File
+
+The `append` operation allows you to add content to the end of an existing file.
+
+#### Specific Parameters
+
+| Parameter   | Type   | Required | Description                               |
+|-------------|--------|----------|-------------------------------------------|
+| `operation` | string | Yes      | Must be `"append"`                        |
+| `path`      | string | Yes      | The path of the file to append content to |
+| `content`   | string | Yes      | The content to add to the end of the file |
+
+#### Return Value
+
+This operation returns an object with the following properties:
+
+| Property   | Type    | Always returned | Description                                |
+|------------|---------|-----------------|--------------------------------------------|
+| `path`     | string  | Yes             | Absolute path of the modified file         |
+| `appended` | boolean | Yes             | Indicates whether the content was appended |
+
+#### Example
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "append"
+    path: "CHANGELOG.md"
+    content: |
+
+      ## v1.0.0 (2023-10-15)
+
+      - Initial release
+```
+
+### Create a File
+
+The `create` operation allows you to create a new file with specified content.
+
+#### Specific Parameters
+
+| Parameter   | Type    | Required | Default Value | Description                                         |
+|-------------|---------|----------|---------------|-----------------------------------------------------|
+| `operation` | string  | Yes      | -             | Must be `"create"`                                  |
+| `path`      | string  | Yes      | -             | The path of the file to create                      |
+| `content`   | string  | No       | -             | The content to write to the file                    |
+| `overwrite` | boolean | No       | `false`       | If `true`, overwrites the file if it already exists |
+
+#### Return Value
+
+This operation returns an object with the following properties:
+
+| Property      | Type    | Always returned | Description                                       |
+|---------------|---------|-----------------|---------------------------------------------------|
+| `path`        | string  | Yes             | Absolute path of the new file                     |
+| `overwritten` | boolean | Yes             | Indicates whether the file was overwritten or not |
+
+#### Example
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "create"
+    path: ".eslintrc.json"
+    content: |
+      {
+        "extends": ["react-app", "prettier"],
+        "plugins": ["react"],
+        "rules": {
+          "react/jsx-uses-react": "error",
+          "react/jsx-uses-vars": "error"
+        }
+      }
+    overwrite: true
+```
+
+### Prepend Content to a File
+
+The `prepend` operation allows you to add content to the beginning of an existing file.
+
+#### Specific Parameters
+
+| Parameter   | Type   | Required | Description                                     |
+|-------------|--------|----------|-------------------------------------------------|
+| `operation` | string | Yes      | Must be `"prepend"`                             |
+| `path`      | string | Yes      | The path of the file to prepend content to      |
+| `content`   | string | Yes      | The content to add to the beginning of the file |
+
+#### Return Value
+
+This operation returns an object with the following properties:
+
+| Property    | Type    | Always returned | Description                                 |
+|-------------|---------|-----------------|---------------------------------------------|
+| `path`      | string  | Yes             | Absolute path of the modified file          |
+| `prepended` | boolean | Yes             | Indicates whether the content was prepended |
+
+#### Example
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "prepend"
+    path: "README.md"
+    content: |
+      # Project Documentation
+
+      This documentation was automatically generated.
+
+```
+
+### Update Content in a File
+
+The `update` operation allows you to replace content in a file using a regular expression pattern.
+
+#### Specific Parameters
+
+| Parameter   | Type   | Required | Description                                     |
+|-------------|--------|----------|-------------------------------------------------|
+| `operation` | string | Yes      | Must be `"update"`                              |
+| `path`      | string | Yes      | The path of the file to update                  |
+| `pattern`   | string | Yes      | The regular expression pattern to search for    |
+| `content`   | string | Yes      | The content to replace the matched pattern with |
+
+#### Return Value
+
+This operation returns an object with the following properties:
+
+| Property  | Type    | Always returned | Description                                               |
+|-----------|---------|-----------------|-----------------------------------------------------------|
+| `path`    | string  | Yes             | Absolute path of the modified file                        |
+| `updated` | boolean | Yes             | Indicates whether any content was updated (pattern found) |
+
+#### Example
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"1.2.0\""
+```
+
+### Using with Variables
+
+All paths and content in the different operations can use variable interpolation to make the action dynamic, using the
+syntax `{VARIABLE_NAME}`.
+
+Additionally, you can use 2 internal variables to access the recipe directory (`$RECIPE_DIRECTORY`) and the current
+project directory (`$PROJECT_DIRECTORY`).
+
+You can also use variables in the content of files:
+
+```yaml
+- name: "Enter project name"
+  action:
+    type: "prompt"
+    promptType: "text"
+    message: "Project name:"
+    defaultValue: "my-project"
+  variable: "PROJECT_NAME"
+
+- action:
+    type: "fileManipulation"
+    operation: "create"
+    path: "README.md"
+    content: |
+      # {PROJECT_NAME}
+
+      This project was created with Codx.
+```
+
+### Error Handling
+
+You can handle errors that may occur during file operations using the `onSuccess` and `onFailure` attributes:
+
+```yaml
+- name: "Update version in package.json"
+  action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"1.2.0\""
+  onSuccess:
+    - action:
+        type: "message"
+        content: "Version updated successfully."
+        style: "success"
+  onFailure:
+    - action:
+        type: "message"
+        content: "Failed to update version. Pattern not found or file doesn't exist."
+        style: "error"
+```
+
+### Best Practices
+
+- **File Existence**: For `prepend`, `append`, and `update` operations, make sure the file exists before attempting to
+  modify it.
+- **Backup**: Make a backup copy of important files before modifying them.
+- **Relative Paths**: Use relative paths rather than absolute paths for better portability.
+- **Overwrite Parameter**: Be careful with the `overwrite: true` parameter in the `create` operation, as it can
+  overwrite existing files without warning.
+- **Regular Expressions**: Test your regular expressions carefully for the `update` operation to ensure they match the
+  intended content.
+- **Error Handling**: Always use `onSuccess` and `onFailure` to handle cases where operations fail.
+
+### Common Use Cases
+
+#### Adding License Headers to Files
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "prepend"
+    path: "src/index.js"
+    content: |
+      /**
+       * Copyright (c) 2023 My Company
+       * Licensed under the MIT License
+       */
+
+```
+
+#### Updating Version Numbers
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"{NEW_VERSION}\""
+```
+
+#### Adding Content to Documentation
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "append"
+    path: "CHANGELOG.md"
+    content: |
+
+      ## v{VERSION} ({RELEASE_DATE})
+
+      {CHANGELOG_CONTENT}
+```
+
+[↑ List of Actions](../actions.md)
+
+[← Fail](fail.md) ─ [FileSystem →](fileSystem.md)

--- a/docs/en/actions/fileSystem.md
+++ b/docs/en/actions/fileSystem.md
@@ -9,18 +9,20 @@ configuration.
 The `fileSystem` action supports [several operations](#operation-details), each with its own parameters:
 
 1. `copy`: [Copy a file or directory](#copy-a-file-or-directory)
-2. `create`: [Create a file](#create-a-file)
-3. `delete`: [Delete a file or directory](#delete-a-file-or-directory)
-4. `exists`: [Check if a file or directory exists](#check-if-a-file-or-directory-exists)
-5. `mkdir`: [Create a directory](#create-a-directory)
-6. `move`: [Move a file or directory](#move-a-file-or-directory)
+2. `delete`: [Delete a file or directory](#delete-a-file-or-directory)
+3. `exists`: [Check if a file or directory exists](#check-if-a-file-or-directory-exists)
+4. `mkdir`: [Create a directory](#create-a-directory)
+5. `move`: [Move a file or directory](#move-a-file-or-directory)
+
+> **Note**: For file content manipulation operations like creating files, adding content to files, or updating content
+> with regular expressions, see the [FileManipulation](fileManipulation.md) action.
 
 ## Common Parameters
 
-| Parameter   | Type   | Required | Description                                                                                  |
-|-------------|--------|----------|----------------------------------------------------------------------------------------------|
-| `type`      | string | Yes      | Must be `"fileSystem"`                                                                       |
-| `operation` | string | Yes      | The operation to perform (`"create"`, `"delete"`, `"exists"`, `"mkdir"`, `"copy"`, `"move"`) |
+| Parameter   | Type   | Required | Description                                                                      |
+|-------------|--------|----------|----------------------------------------------------------------------------------|
+| `type`      | string | Yes      | Must be `"fileSystem"`                                                           |
+| `operation` | string | Yes      | The operation to perform (`"delete"`, `"exists"`, `"mkdir"`, `"copy"`, `"move"`) |
 
 ## Operation Details
 
@@ -74,47 +76,6 @@ something like this:
     operation: "copy"
     source: "{$RECIPE_DIRECTORY}/templates/.eslintrc.json"
     destination: "{$PROJECT_DIRECTORY}/.eslintrc.json"
-    overwrite: true
-```
-
-### Create a File
-
-The `create` operation allows you to create a new file with specified content.
-
-#### Specific Parameters
-
-| Parameter   | Type    | Required | Default Value | Description                                         |
-|-------------|---------|----------|---------------|-----------------------------------------------------|
-| `operation` | string  | Yes      | -             | Must be `"create"`                                  |
-| `path`      | string  | Yes      | -             | The path of the file to create                      |
-| `content`   | string  | No       | -             | The content to write to the file                    |
-| `overwrite` | boolean | No       | `false`       | If `true`, overwrites the file if it already exists |
-
-#### Return Value
-
-This operation returns an object with the following properties:
-
-| Property      | Type    | Always returned | Description                                       |
-|---------------|---------|-----------------|---------------------------------------------------|
-| `path`        | string  | Yes             | Absolute path of the new file                     |
-| `overwritten` | boolean | Yes             | Indicates whether the file was overwritten or not |
-
-#### Example
-
-```yaml
-- action:
-    type: "fileSystem"
-    operation: "create"
-    path: ".eslintrc.json"
-    content: |
-      {
-        "extends": ["react-app", "prettier"],
-        "plugins": ["react"],
-        "rules": {
-          "react/jsx-uses-react": "error",
-          "react/jsx-uses-vars": "error"
-        }
-      }
     overwrite: true
 ```
 
@@ -376,4 +337,4 @@ You can handle errors that may occur during file operations using the `onSuccess
 
 [↑ List of Actions](../actions.md)
 
-[← Fail](fail.md) ─ [Message →](message.md)
+[← FileManipulation](fileManipulation.md) ─ [Message →](message.md)

--- a/docs/fr/actions/fail.md
+++ b/docs/fr/actions/fail.md
@@ -1,13 +1,14 @@
 # Action Fail
 
-L'action `fail` permet de lever intentionnellement une erreur pendant l'exécution d'une recette. Cette action est utile pour arrêter l'exécution d'une recette lorsqu'une condition spécifique n'est pas remplie.
+L'action `fail` permet de lever intentionnellement une erreur pendant l'exécution d'une recette. Cette action est utile
+pour arrêter l'exécution d'une recette lorsqu'une condition spécifique n'est pas remplie.
 
 ## Paramètres
 
-| Paramètre | Type   | Obligatoire | Description                                                                                |
-|-----------|--------|-------------|--------------------------------------------------------------------------------------------|
-| `type`    | string | Oui         | Doit être `"fail"`                                                                         |
-| `message` | string | Non         | Le message d'erreur à afficher. Par défaut : "Explicit failure triggered by fail action"   |
+| Paramètre | Type   | Obligatoire | Description                                                                              |
+|-----------|--------|-------------|------------------------------------------------------------------------------------------|
+| `type`    | string | Oui         | Doit être `"fail"`                                                                       |
+| `message` | string | Non         | Le message d'erreur à afficher. Par défaut : "Explicit failure triggered by fail action" |
 
 ## Valeur de retour
 
@@ -41,7 +42,8 @@ Cette action ne retourne pas de valeur car elle lève toujours une erreur.
 
 ## Utilisation avec onFailure
 
-L'action `fail` est particulièrement utile en combinaison avec les blocs `onFailure` pour implémenter une gestion d'erreur personnalisée :
+L'action `fail` est particulièrement utile en combinaison avec les blocs `onFailure` pour implémenter une gestion
+d'erreur personnalisée :
 
 ```yaml
 - name: "Valider la configuration"
@@ -61,9 +63,12 @@ L'action `fail` est particulièrement utile en combinaison avec les blocs `onFai
 
 ## Bonnes pratiques
 
-- **Messages d'erreur clairs** : Fournissez des messages d'erreur descriptifs qui expliquent pourquoi l'échec s'est produit.
-- **Échecs conditionnels** : Utilisez l'attribut `condition` pour rendre les échecs conditionnels en fonction de critères spécifiques.
-- **Récupération d'erreur** : Fournissez toujours un bloc `onFailure` lorsque vous souhaitez récupérer de l'erreur et continuer l'exécution.
+- **Messages d'erreur clairs** : Fournissez des messages d'erreur descriptifs qui expliquent pourquoi l'échec s'est
+  produit.
+- **Échecs conditionnels** : Utilisez l'attribut `condition` pour rendre les échecs conditionnels en fonction de
+  critères spécifiques.
+- **Récupération d'erreur** : Fournissez toujours un bloc `onFailure` lorsque vous souhaitez récupérer de l'erreur et
+  continuer l'exécution.
 
 ## Alternatives
 
@@ -74,4 +79,4 @@ Pour certains scénarios, vous pourriez envisager ces alternatives :
 
 [↑ Liste des actions](../actions.md)
 
-[← Command](command.md) ─ [FileSystem →](fileSystem.md)
+[← Command](command.md) ─ [FileManipulation →](fileManipulation.md)

--- a/docs/fr/actions/fileManipulation.md
+++ b/docs/fr/actions/fileManipulation.md
@@ -1,0 +1,280 @@
+# Action FileManipulation
+
+L'action `fileManipulation` permet de créer et manipuler le contenu des fichiers pendant l'exécution d'une recette.
+Cette action est essentielle pour créer des fichiers, ajouter du contenu au début ou à la fin des fichiers, et mettre à
+jour le contenu en utilisant des expressions régulières.
+
+## Opérations disponibles
+
+L'action `fileManipulation` prend en charge [plusieurs opérations](#détails-des-opérations), chacune avec ses propres
+paramètres :
+
+1. `append`: [Ajouter du contenu à la fin d'un fichier](#ajouter-du-contenu-à-la-fin-dun-fichier)
+2. `create`: [Créer un fichier](#créer-un-fichier)
+3. `prepend`: [Ajouter du contenu au début d'un fichier](#ajouter-du-contenu-au-début-dun-fichier)
+4. `update`: [Mettre à jour le contenu d'un fichier](#mettre-à-jour-le-contenu-dun-fichier)
+
+## Paramètres communs
+
+| Paramètre   | Type   | Obligatoire | Description                                                               |
+|-------------|--------|-------------|---------------------------------------------------------------------------|
+| `type`      | string | Oui         | Doit être `"fileManipulation"`                                            |
+| `operation` | string | Oui         | L'opération à effectuer (`"create"`, `"prepend"`, `"append"`, `"update"`) |
+
+## Détails des opérations
+
+### Ajouter du contenu à la fin d'un fichier
+
+L'opération `append` permet d'ajouter du contenu à la fin d'un fichier existant.
+
+#### Paramètres spécifiques
+
+| Paramètre   | Type   | Obligatoire | Description                                    |
+|-------------|--------|-------------|------------------------------------------------|
+| `operation` | string | Oui         | Doit être `"append"`                           |
+| `path`      | string | Oui         | Le chemin du fichier auquel ajouter du contenu |
+| `content`   | string | Oui         | Le contenu à ajouter à la fin du fichier       |
+
+#### Valeur de retour
+
+Cette opération retourne un objet avec les propriétés suivantes :
+
+| Propriété  | Type    | Toujours retourné | Description                                            |
+|------------|---------|-------------------|--------------------------------------------------------|
+| `path`     | string  | Oui               | Chemin absolu du fichier modifié                       |
+| `appended` | boolean | Oui               | Indique si le contenu a été ajouté à la fin du fichier |
+
+#### Exemple
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "append"
+    path: "CHANGELOG.md"
+    content: |
+
+      ## v1.0.0 (2025-02-13)
+
+      - Version initiale
+```
+
+### Créer un fichier
+
+L'opération `create` permet de créer un nouveau fichier avec un contenu spécifié.
+
+#### Paramètres spécifiques
+
+| Paramètre   | Type    | Obligatoire | Valeur par défaut | Description                                   |
+|-------------|---------|-------------|-------------------|-----------------------------------------------|
+| `operation` | string  | Oui         | -                 | Doit être `"create"`                          |
+| `path`      | string  | Oui         | -                 | Le chemin du fichier à créer                  |
+| `content`   | string  | Non         | -                 | Le contenu à écrire dans le fichier           |
+| `overwrite` | boolean | Non         | `false`           | Si `true`, écrase le fichier s'il existe déjà |
+
+#### Valeur de retour
+
+Cette opération retourne un objet avec les propriétés suivantes :
+
+| Propriété     | Type    | Toujours retourné | Description                               |
+|---------------|---------|-------------------|-------------------------------------------|
+| `path`        | string  | Oui               | Chemin absolu du nouveau fichier          |
+| `overwritten` | boolean | Oui               | Indique si le fichier a été écrasé ou non |
+
+#### Exemple
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "create"
+    path: ".eslintrc.json"
+    content: |
+      {
+        "extends": ["react-app", "prettier"],
+        "plugins": ["react"],
+        "rules": {
+          "react/jsx-uses-react": "error",
+          "react/jsx-uses-vars": "error"
+        }
+      }
+    overwrite: true
+```
+
+### Ajouter du contenu au début d'un fichier
+
+L'opération `prepend` permet d'ajouter du contenu au début d'un fichier existant.
+
+#### Paramètres spécifiques
+
+| Paramètre   | Type   | Obligatoire | Description                                    |
+|-------------|--------|-------------|------------------------------------------------|
+| `operation` | string | Oui         | Doit être `"prepend"`                          |
+| `path`      | string | Oui         | Le chemin du fichier auquel ajouter du contenu |
+| `content`   | string | Oui         | Le contenu à ajouter au début du fichier       |
+
+#### Valeur de retour
+
+Cette opération retourne un objet avec les propriétés suivantes :
+
+| Propriété   | Type    | Toujours retourné | Description                                            |
+|-------------|---------|-------------------|--------------------------------------------------------|
+| `path`      | string  | Oui               | Chemin absolu du fichier modifié                       |
+| `prepended` | boolean | Oui               | Indique si le contenu a été ajouté au début du fichier |
+
+#### Exemple
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "prepend"
+    path: "README.md"
+    content: |
+      # Documentation du projet
+
+      Cette documentation a été générée automatiquement.
+
+```
+
+### Mettre à jour le contenu d'un fichier
+
+L'opération `update` permet de remplacer du contenu dans un fichier en utilisant une expression régulière.
+
+#### Paramètres spécifiques
+
+| Paramètre   | Type   | Obligatoire | Description                                            |
+|-------------|--------|-------------|--------------------------------------------------------|
+| `operation` | string | Oui         | Doit être `"update"`                                   |
+| `path`      | string | Oui         | Le chemin du fichier à mettre à jour                   |
+| `pattern`   | string | Oui         | L'expression régulière à rechercher                    |
+| `content`   | string | Oui         | Le contenu qui remplacera les correspondances trouvées |
+
+#### Valeur de retour
+
+Cette opération retourne un objet avec les propriétés suivantes :
+
+| Propriété | Type    | Toujours retourné | Description                                           |
+|-----------|---------|-------------------|-------------------------------------------------------|
+| `path`    | string  | Oui               | Chemin absolu du fichier modifié                      |
+| `updated` | boolean | Oui               | Indique si du contenu a été mis à jour (motif trouvé) |
+
+#### Exemple
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"1.2.0\""
+```
+
+### Utilisation avec des variables
+
+Tous les chemins et contenus des différentes opérations peuvent utiliser l'interpolation de variables afin de rendre l'
+action dynamique, en utilisant la syntaxe `{VARIABLE_NAME}`.
+
+De plus, vous pouvez utiliser 2 variables internes pour accéder aux répertoires de la recette (`$RECIPE_DIRECTORY`) et
+le répertoire courant du projet (`$PROJECT_DIRECTORY`).
+
+Vous pouvez également utiliser des variables dans le contenu des fichiers :
+
+```yaml
+- name: "Saisir le nom du projet"
+  action:
+    type: "prompt"
+    promptType: "text"
+    message: "Nom du projet :"
+    defaultValue: "mon-projet"
+  variable: "PROJECT_NAME"
+
+- action:
+    type: "fileManipulation"
+    operation: "create"
+    path: "README.md"
+    content: |
+      # {PROJECT_NAME}
+
+      Ce projet a été créé avec Codx.
+```
+
+### Gestion des erreurs
+
+Vous pouvez gérer les erreurs qui peuvent survenir lors des opérations sur les fichiers en utilisant les attributs
+`onSuccess` et `onFailure` :
+
+```yaml
+- name: "Mettre à jour la version dans package.json"
+  action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"1.2.0\""
+  onSuccess:
+    - action:
+        type: "message"
+        content: "Version mise à jour avec succès."
+        style: "success"
+  onFailure:
+    - action:
+        type: "message"
+        content: "Échec de la mise à jour de la version. Motif non trouvé ou fichier inexistant."
+        style: "error"
+```
+
+### Bonnes pratiques
+
+- **Existence du fichier** : Pour les opérations `prepend`, `append` et `update`, assurez-vous que le fichier existe
+  avant de tenter de le modifier.
+- **Sauvegarde** : Faites une copie de sauvegarde des fichiers importants avant de les modifier.
+- **Chemins relatifs** : Utilisez des chemins relatifs plutôt que des chemins absolus pour une meilleure portabilité.
+- **Paramètre overwrite** : Soyez prudent avec le paramètre `overwrite: true` dans l'opération `create`, car il peut
+  écraser des fichiers existants sans avertissement.
+- **Expressions régulières** : Testez soigneusement vos expressions régulières pour l'opération `update` afin de vous
+  assurer qu'elles correspondent au contenu prévu.
+- **Gestion des erreurs** : Utilisez toujours `onSuccess` et `onFailure` pour gérer les cas où les opérations échouent.
+
+### Cas d'utilisation courants
+
+#### Ajout d'en-têtes de licence aux fichiers
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "prepend"
+    path: "src/index.js"
+    content: |
+      /**
+       * Copyright (c) 2023 Ma Société
+       * Sous licence MIT
+       */
+
+```
+
+#### Mise à jour des numéros de version
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "update"
+    path: "package.json"
+    pattern: "\"version\": \"[0-9]+\\.[0-9]+\\.[0-9]+\""
+    content: "\"version\": \"{NOUVELLE_VERSION}\""
+```
+
+#### Ajout de contenu à la documentation
+
+```yaml
+- action:
+    type: "fileManipulation"
+    operation: "append"
+    path: "CHANGELOG.md"
+    content: |
+
+      ## v{VERSION} ({DATE_SORTIE})
+
+      {CONTENU_CHANGELOG}
+```
+
+[↑ Liste des actions](../actions.md)
+
+[← Fail](fail.md) ─ [FileSystem →](fileSystem.md) 

--- a/docs/fr/actions/fileSystem.md
+++ b/docs/fr/actions/fileSystem.md
@@ -6,22 +6,25 @@ de l'automatisation de la configuration de projets.
 
 ## Opérations disponibles
 
-L'action `fileSystem` prend en charge [plusieurs opérations](#détail-des-opérations), chacune avec ses propres
+L'action `fileSystem` prend en charge [plusieurs opérations](#détails-des-opérations), chacune avec ses propres
 paramètres :
 
 1. `copy`: [Copier un fichier ou un répertoire](#copier-un-fichier-ou-un-répertoire)
-2. `create`: [Créer un fichier](#créer-un-fichier)
-3. `delete`: [Supprimer un fichier ou un répertoire](#supprimer-un-fichier-ou-un-répertoire)
-4. `exists`: [Vérifier si un fichier ou un répertoire existe](#vérifier-si-un-fichier-ou-un-répertoire-existe)
-5. `mkdir`: [Créer un répertoire](#créer-un-répertoire)
-6. `move`: [Déplacer un fichier ou un répertoire](#déplacer-un-fichier-ou-un-répertoire)
+2. `delete`: [Supprimer un fichier ou un répertoire](#supprimer-un-fichier-ou-un-répertoire)
+3. `exists`: [Vérifier si un fichier ou un répertoire existe](#vérifier-si-un-fichier-ou-un-répertoire-existe)
+4. `mkdir`: [Créer un répertoire](#créer-un-répertoire)
+5. `move`: [Déplacer un fichier ou un répertoire](#déplacer-un-fichier-ou-un-répertoire)
+
+> **Note**: Pour les opérations de manipulation du contenu des fichiers comme la création de fichiers, l'ajout de
+> contenu aux fichiers, ou la mise à jour de contenu avec des expressions régulières, consultez
+> l'action [FileManipulation](fileManipulation.md).
 
 ## Paramètres communs
 
-| Paramètre   | Type   | Obligatoire | Description                                                                                 |
-|-------------|--------|-------------|---------------------------------------------------------------------------------------------|
-| `type`      | string | Oui         | Doit être `"fileSystem"`                                                                    |
-| `operation` | string | Oui         | L'opération à effectuer (`"create"`, `"delete"`, `"exists"`, `"mkdir"`, `"copy"`, `"move"`) |
+| Paramètre   | Type   | Obligatoire | Description                                                                     |
+|-------------|--------|-------------|---------------------------------------------------------------------------------|
+| `type`      | string | Oui         | Doit être `"fileSystem"`                                                        |
+| `operation` | string | Oui         | L'opération à effectuer (`"delete"`, `"exists"`, `"mkdir"`, `"copy"`, `"move"`) |
 
 ## Détails des opérations
 
@@ -79,47 +82,6 @@ votre projet, vous pouvez faire quelque chose comme cela :
     overwrite: true
 ```
 
-### Créer un fichier
-
-L'opération `create` permet de créer un nouveau fichier avec un contenu spécifié.
-
-#### Paramètres spécifiques
-
-| Paramètre   | Type    | Obligatoire | Valeur par défaut | Description                                   |
-|-------------|---------|-------------|-------------------|-----------------------------------------------|
-| `operation` | string  | Oui         | -                 | Doit être `"create"`                          |
-| `path`      | string  | Oui         | -                 | Le chemin du fichier à créer                  |
-| `content`   | string  | Non         | -                 | Le contenu à écrire dans le fichier           |
-| `overwrite` | boolean | Non         | `false`           | Si `true`, écrase le fichier s'il existe déjà |
-
-#### Valeur de retour
-
-Cette opération retourne un objet avec les propriétés suivantes :
-
-| Propriété     | Type    | Toujours retourné | Description                               |
-|---------------|---------|-------------------|-------------------------------------------|
-| `path`        | string  | Oui               | Chemin absolu du nouveau fichier          |
-| `overwritten` | boolean | Oui               | Indique si le fichier a été écrasé ou non |
-
-#### Exemple
-
-```yaml
-- action:
-    type: "fileSystem"
-    operation: "create"
-    path: ".eslintrc.json"
-    content: |
-      {
-        "extends": ["react-app", "prettier"],
-        "plugins": ["react"],
-        "rules": {
-          "react/jsx-uses-react": "error",
-          "react/jsx-uses-vars": "error"
-        }
-      }
-    overwrite: true
-```
-
 ### Supprimer un fichier ou un répertoire
 
 L'opération `delete` permet de supprimer un fichier ou un répertoire.
@@ -129,7 +91,7 @@ L'opération `delete` permet de supprimer un fichier ou un répertoire.
 | Paramètre   | Type   | Obligatoire | Description                                       |
 |-------------|--------|-------------|---------------------------------------------------|
 | `operation` | string | Oui         | Doit être `"delete"`                              |
-| `path`      | string | Oui         | Le chemin du fichier ou du répertoire à supprimer |
+| `path`      | string | Oui         | Le chemin du fichier ou du répertoire à supprimer | 
 
 #### Valeur de retour
 
@@ -380,4 +342,4 @@ Vous pouvez gérer les erreurs qui peuvent survenir lors des opérations sur les
 
 [↑ Liste des actions](../actions.md)
 
-[← Fail](fail.md) ─ [Message →](message.md)
+[← FileManipulation](fileManipulation.md) ─ [Message →](message.md)

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "version:post:generate-cli": "bun run generate:cli && git add dist/cli.js",
     "version:post:generate-schema": "bun run generate:json-schema && git add dist/codx-schema.json",
     "version:post:commit-develop": "export VERSION=$(node -p \"require('./package.json').version\") && git add package.json && git commit --no-edit -mv$VERSION",
+    "version:post:push-develop": "git push origin develop",
     "version:post:merge-main": "git checkout main && git pull && git merge develop",
     "version:post:tag-main": "export VERSION=$(node -p \"require('./package.json').version\") && git tag $VERSION",
-    "--version:post:push": "git push origin main --tags",
+    "version:post:push-main": "git push origin main --tags",
     "version:post:checkout-develop": "git checkout develop"
   },
   "files": [

--- a/src/actions/ActionRegistry.ts
+++ b/src/actions/ActionRegistry.ts
@@ -2,6 +2,7 @@ import { IAction } from '@/actions/Action.interface';
 import { ChangeDirAction } from '@/actions/changeDir/ChangeDirAction';
 import { CommandAction } from '@/actions/command/CommandAction';
 import { FailAction } from '@/actions/fail/FailAction';
+import { FileManipulationAction } from '@/actions/fileManipulation/FileManipulationAction';
 import { FileSystemAction } from '@/actions/fileSystem/FileSystemAction';
 import { MessageAction } from '@/actions/message/MessageAction';
 import { PackageAction } from '@/actions/package/PackageAction';
@@ -14,6 +15,7 @@ export const actionRegistry: ActionRegistry = {
   changeDir: ChangeDirAction,
   command: CommandAction,
   fail: FailAction,
+  fileManipulation: FileManipulationAction,
   fileSystem: FileSystemAction,
   message: MessageAction,
   package: PackageAction,

--- a/src/actions/Actions.schema.ts
+++ b/src/actions/Actions.schema.ts
@@ -1,6 +1,7 @@
 import { ChangeDirActionDataSchema } from '@/actions/changeDir/ChangeDirAction.schema';
 import { CommandActionDataSchema } from '@/actions/command/CommandAction.schema';
 import { FailActionDataSchema } from '@/actions/fail/FailAction.schema';
+import { FileManipulationActionDataSchema } from '@/actions/fileManipulation/FileManipulationAction.schema';
 import { FileSystemActionDataSchema } from '@/actions/fileSystem/FileSystemAction.schema';
 import { MessageActionDataSchema } from '@/actions/message/MessageAction.schema';
 import { PackageActionDataSchema } from '@/actions/package/PackageAction.schema';
@@ -13,6 +14,7 @@ export const ActionsDataSchema = z
     ChangeDirActionDataSchema,
     CommandActionDataSchema,
     FailActionDataSchema,
+    FileManipulationActionDataSchema,
     FileSystemActionDataSchema,
     MessageActionDataSchema,
     PackageActionDataSchema,

--- a/src/actions/fileManipulation/FileManipulationAction.schema.ts
+++ b/src/actions/fileManipulation/FileManipulationAction.schema.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+// append
+export const FileManipulationActionAppendDataSchema = z
+  .object({
+    type: z.literal('fileManipulation'),
+    operation: z.literal('append'),
+    path: z.string(),
+    content: z.string(),
+  })
+  .describe('FileManipulationActionAppendDataSchema');
+
+export type FileManipulationActionAppendData = z.infer<typeof FileManipulationActionAppendDataSchema>;
+
+// create
+export const FileManipulationActionCreateDataSchema = z
+  .object({
+    type: z.literal('fileManipulation'),
+    operation: z.literal('create'),
+    path: z.string(),
+    content: z.string().optional(),
+    overwrite: z.boolean().optional().default(false),
+  })
+  .describe('FileManipulationActionCreateDataSchema');
+
+export type FileManipulationActionCreateData = z.infer<typeof FileManipulationActionCreateDataSchema>;
+
+// prepend
+export const FileManipulationActionPrependDataSchema = z
+  .object({
+    type: z.literal('fileManipulation'),
+    operation: z.literal('prepend'),
+    path: z.string(),
+    content: z.string(),
+  })
+  .describe('FileManipulationActionPrependDataSchema');
+
+export type FileManipulationActionPrependData = z.infer<typeof FileManipulationActionPrependDataSchema>;
+
+// update
+export const FileManipulationActionUpdateDataSchema = z
+  .object({
+    type: z.literal('fileManipulation'),
+    operation: z.literal('update'),
+    path: z.string(),
+    pattern: z.string(),
+    content: z.string(),
+  })
+  .describe('FileManipulationActionUpdateDataSchema');
+
+export type FileManipulationActionUpdateData = z.infer<typeof FileManipulationActionUpdateDataSchema>;
+
+export const FileManipulationActionDataSchema = z
+  .union([
+    FileManipulationActionAppendDataSchema,
+    FileManipulationActionCreateDataSchema,
+    FileManipulationActionPrependDataSchema,
+    FileManipulationActionUpdateDataSchema,
+  ])
+  .describe('FileManipulationActionDataSchema');
+
+export type FileManipulationActionData = z.infer<typeof FileManipulationActionDataSchema>;

--- a/src/actions/fileManipulation/FileManipulationAction.spec.ts
+++ b/src/actions/fileManipulation/FileManipulationAction.spec.ts
@@ -1,0 +1,483 @@
+import { FileManipulationAction } from '@/actions/fileManipulation/FileManipulationAction';
+import {
+  FileManipulationActionAppendData,
+  FileManipulationActionCreateData,
+  FileManipulationActionData,
+  FileManipulationActionPrependData,
+  FileManipulationActionUpdateData,
+} from '@/actions/fileManipulation/FileManipulationAction.schema';
+import { CodxError } from '@/core/CodxError';
+import { Store } from '@/core/Store';
+import { diContainer } from '@/di/Container';
+import { MockCleaner, mockModule } from '@/testHelpers/mockModule';
+import { setupConsole } from '@/testHelpers/setupConsole';
+import { setupWorkingDirectories } from '@/testHelpers/setupWorkingDirectories';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+
+describe('FileManipulationAction', () => {
+  const { mockProjectDir } = setupWorkingDirectories();
+  setupConsole();
+
+  const mockFilePath = 'test/file.txt';
+  const mockAbsolutePath = `${mockProjectDir}/${mockFilePath}`;
+  const mockContent = 'Test content';
+  const mockInterpolatedContent = 'Interpolated test content';
+  const mockPrependContent = 'Prepend content';
+  const mockInterpolatedPrependContent = 'Interpolated prepend content';
+  const mockAppendContent = 'Append content';
+  const mockInterpolatedAppendContent = 'Interpolated append content';
+  const mockExistingContent = 'Existing content';
+  const mockPattern = 'Existing';
+  const mockInterpolatedPattern = 'Existing';
+  const mockUpdateContent = 'Updated';
+  const mockInterpolatedUpdateContent = 'Updated';
+
+  // Regex test content and patterns
+  const mockRegexContent = 'This is a test string with multiple words. This is a second sentence.';
+  const mockRegexSpecialCharsPattern = 'a .* with';
+  const mockRegexCaptureGroupPattern = '(This) is';
+  const mockRegexCaptureGroupReplacement = 'That was';
+  const mockRegexMultipleMatchesPattern = 'This';
+  const mockRegexMultipleMatchesReplacement = 'That';
+  const mockRegexLineStartPattern = '^This';
+  const mockRegexLineEndPattern = 'sentence\\.$';
+  const mockComplexRegexPattern = '(\\w+) is a (\\w+)';
+  const mockComplexRegexReplacement = '$2 was my $1';
+
+  let mockFsCleaner: MockCleaner;
+  let action: FileManipulationAction;
+
+  beforeEach(async () => {
+    mockFsCleaner = await mockModule('fs', () => ({
+      existsSync: mock(),
+      writeFileSync: mock(),
+      readFileSync: mock(),
+      mkdirSync: mock(),
+    }));
+
+    const mockStore = diContainer.get(Store);
+    spyOn(mockStore, 'interpolate').mockImplementation((value) => {
+      if (value === mockContent) {
+        return mockInterpolatedContent;
+      }
+      if (value === mockPrependContent) {
+        return mockInterpolatedPrependContent;
+      }
+      if (value === mockAppendContent) {
+        return mockInterpolatedAppendContent;
+      }
+      if (value === mockPattern) {
+        return mockInterpolatedPattern;
+      }
+      if (value === mockUpdateContent) {
+        return mockInterpolatedUpdateContent;
+      }
+      if (value === mockRegexCaptureGroupPattern) {
+        return mockRegexCaptureGroupPattern;
+      }
+      if (value === mockRegexCaptureGroupReplacement) {
+        return mockRegexCaptureGroupReplacement;
+      }
+      if (value === mockRegexSpecialCharsPattern) {
+        return mockRegexSpecialCharsPattern;
+      }
+      if (value === mockRegexMultipleMatchesPattern) {
+        return mockRegexMultipleMatchesPattern;
+      }
+      if (value === mockRegexMultipleMatchesReplacement) {
+        return mockRegexMultipleMatchesReplacement;
+      }
+      if (value === mockRegexLineStartPattern) {
+        return mockRegexLineStartPattern;
+      }
+      if (value === mockRegexLineEndPattern) {
+        return mockRegexLineEndPattern;
+      }
+      if (value === mockComplexRegexPattern) {
+        return mockComplexRegexPattern;
+      }
+      if (value === mockComplexRegexReplacement) {
+        return mockComplexRegexReplacement;
+      }
+
+      return value;
+    });
+
+    // Reset fs mocks
+    (existsSync as any).mockReset();
+    (writeFileSync as any).mockReset();
+    (readFileSync as any).mockReset();
+    (mkdirSync as any).mockReset();
+
+    action = diContainer.get(FileManipulationAction);
+  });
+
+  afterEach(() => {
+    mockFsCleaner();
+    mock.restore();
+  });
+
+  describe('Operation CREATE', () => {
+    test('should create a file with content', async () => {
+      // Mock file does not exist
+      (existsSync as any).mockReturnValue(false);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'create',
+        path: mockFilePath,
+        content: mockContent,
+      } as FileManipulationActionCreateData;
+
+      await action.execute(actionData);
+
+      expect(writeFileSync).toHaveBeenCalledWith(mockAbsolutePath, mockInterpolatedContent);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('File created successfully'));
+    });
+
+    test('should throw error when file exists and overwrite option is not enabled', async () => {
+      (existsSync as any).mockReturnValue(true);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'create',
+        path: mockFilePath,
+        content: mockContent,
+      } as FileManipulationActionData;
+
+      expect(action.execute(actionData)).rejects.toThrow(CodxError);
+      expect(action.execute(actionData)).rejects.toThrow('already exists and the "overwrite" option is not enabled');
+    });
+
+    test('should create a file with content when file exists and overwrite option is enabled', async () => {
+      (existsSync as any).mockReturnValue(true);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'create',
+        path: mockFilePath,
+        content: mockContent,
+        overwrite: true,
+      } as FileManipulationActionData;
+
+      await action.execute(actionData);
+
+      expect(writeFileSync).toHaveBeenCalledWith(mockAbsolutePath, mockInterpolatedContent);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('File created successfully'));
+    });
+  });
+
+  describe('Operation PREPEND', () => {
+    test('should prepend content to a file', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockExistingContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'prepend',
+        path: mockFilePath,
+        content: mockPrependContent,
+      } as FileManipulationActionPrependData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        mockInterpolatedPrependContent + mockExistingContent,
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content prepended successfully'));
+    });
+
+    test('should throw error when file does not exist', async () => {
+      (existsSync as any).mockReturnValue(false);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'prepend',
+        path: mockFilePath,
+        content: mockPrependContent,
+      } as FileManipulationActionPrependData;
+
+      expect(action.execute(actionData)).rejects.toThrow(CodxError);
+      expect(action.execute(actionData)).rejects.toThrow('does not exist');
+    });
+  });
+
+  describe('Operation APPEND', () => {
+    test('should append content to a file', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockExistingContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'append',
+        path: mockFilePath,
+        content: mockAppendContent,
+      } as FileManipulationActionAppendData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(mockAbsolutePath, mockExistingContent + mockInterpolatedAppendContent);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content appended successfully'));
+    });
+
+    test('should throw error when file does not exist', async () => {
+      (existsSync as any).mockReturnValue(false);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'append',
+        path: mockFilePath,
+        content: mockAppendContent,
+      } as FileManipulationActionAppendData;
+
+      expect(action.execute(actionData)).rejects.toThrow(CodxError);
+      expect(action.execute(actionData)).rejects.toThrow('does not exist');
+    });
+  });
+
+  describe('Operation UPDATE', () => {
+    test('should update content in a file using a regex pattern', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockExistingContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockPattern,
+        content: mockUpdateContent,
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        mockExistingContent.replace(new RegExp(mockInterpolatedPattern, 'g'), mockInterpolatedUpdateContent),
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should throw error when file does not exist', async () => {
+      (existsSync as any).mockReturnValue(false);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockPattern,
+        content: mockUpdateContent,
+      } as FileManipulationActionUpdateData;
+
+      expect(action.execute(actionData)).rejects.toThrow(CodxError);
+      expect(action.execute(actionData)).rejects.toThrow('does not exist');
+    });
+
+    test('should log warning when pattern is not found', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue('Content without pattern');
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockPattern,
+        content: mockUpdateContent,
+      } as FileManipulationActionUpdateData;
+
+      const result = await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Pattern'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('not found'));
+      expect(result).toEqual({
+        path: mockAbsolutePath,
+        updated: false,
+      });
+    });
+
+    test('should throw error when pattern is invalid', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockExistingContent);
+
+      // Mock RegExp to throw an error
+      const originalRegExp = global.RegExp;
+      global.RegExp = function () {
+        throw new Error('Invalid regex');
+      } as any;
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockPattern,
+        content: mockUpdateContent,
+      } as FileManipulationActionUpdateData;
+
+      expect(action.execute(actionData)).rejects.toThrow(CodxError);
+      expect(action.execute(actionData)).rejects.toThrow('Invalid regular expression pattern');
+
+      // Restore original RegExp
+      global.RegExp = originalRegExp;
+    });
+
+    test('should update content using regex with special characters', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockRegexSpecialCharsPattern,
+        content: 'a TEST with',
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'This is a TEST with multiple words. This is a second sentence.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should update content using regex with capture groups', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockRegexCaptureGroupPattern,
+        content: mockRegexCaptureGroupReplacement,
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'That was a test string with multiple words. That was a second sentence.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should update content with multiple matches', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockRegexMultipleMatchesPattern,
+        content: mockRegexMultipleMatchesReplacement,
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'That is a test string with multiple words. That is a second sentence.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should update content using regex with line start anchor', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockRegexLineStartPattern,
+        content: 'That',
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'That is a test string with multiple words. This is a second sentence.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should update content using regex with line end anchor', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockRegexLineEndPattern,
+        content: 'paragraph.',
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'This is a test string with multiple words. This is a second paragraph.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+
+    test('should update content using complex regex with capture groups and backreferences', async () => {
+      // Mock file exists
+      (existsSync as any).mockReturnValue(true);
+      (readFileSync as any).mockReturnValue(mockRegexContent);
+
+      const actionData = {
+        type: 'fileManipulation',
+        operation: 'update',
+        path: mockFilePath,
+        pattern: mockComplexRegexPattern,
+        content: mockComplexRegexReplacement,
+      } as FileManipulationActionUpdateData;
+
+      await action.execute(actionData);
+
+      expect(readFileSync).toHaveBeenCalledWith(mockAbsolutePath, 'utf8');
+      expect(writeFileSync).toHaveBeenCalledWith(
+        mockAbsolutePath,
+        'test was my This string with multiple words. second was my This sentence.',
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Content updated successfully'));
+    });
+  });
+
+  test('should throw error for unrecognized operation', async () => {
+    const actionData = {
+      type: 'fileManipulation',
+      operation: 'invalid' as any,
+      path: mockFilePath,
+    } as FileManipulationActionData;
+
+    expect(action.execute(actionData)).rejects.toThrow(CodxError);
+    expect(action.execute(actionData)).rejects.toThrow('Unrecognized file manipulation operation: invalid');
+  });
+});

--- a/src/actions/fileManipulation/FileManipulationAction.ts
+++ b/src/actions/fileManipulation/FileManipulationAction.ts
@@ -1,0 +1,174 @@
+import { BaseAction } from '@/actions/BaseAction';
+import {
+  FileManipulationActionAppendData,
+  FileManipulationActionCreateData,
+  FileManipulationActionData,
+  FileManipulationActionPrependData,
+  FileManipulationActionUpdateData,
+} from '@/actions/fileManipulation/FileManipulationAction.schema';
+import { CodxError } from '@/core/CodxError';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Action to manipulate file content
+ */
+export class FileManipulationAction extends BaseAction {
+  /**
+   * Executes the action on a file
+   * @param {FileManipulationActionData} actionData Action data
+   */
+  public async execute(actionData: FileManipulationActionData) {
+    const { operation } = actionData;
+
+    switch (operation) {
+      case 'append':
+        return this.executeAppend(actionData);
+
+      case 'create':
+        return this.executeCreate(actionData);
+
+      case 'prepend':
+        return this.executePrepend(actionData);
+
+      case 'update':
+        return this.executeUpdate(actionData);
+
+      default:
+        throw new CodxError(`Unrecognized file manipulation operation: ${operation}`);
+    }
+  }
+
+  /**
+   * Appends content to the end of a file
+   * @param {FileManipulationActionAppendData} actionData Action data
+   */
+  private executeAppend(actionData: FileManipulationActionAppendData) {
+    const { path, content } = actionData;
+
+    const interpolatedPath = this.interpolate(path);
+    const absolutePath = this.context.projectDirectory.resolve(interpolatedPath);
+
+    if (!existsSync(absolutePath)) {
+      throw new CodxError(`File "${absolutePath}" does not exist.`);
+    }
+
+    const interpolatedContent = this.interpolate(content);
+    const existingContent = readFileSync(absolutePath, 'utf8');
+    const newContent = existingContent + interpolatedContent;
+
+    writeFileSync(absolutePath, newContent);
+    this.logger.success(`Content appended successfully to: ${absolutePath}`);
+
+    return {
+      path: absolutePath,
+      appended: true,
+    };
+  }
+
+  /**
+   * Creates a file with the specified content
+   * @param {FileManipulationActionCreateData} actionData Action data
+   */
+  private executeCreate(actionData: FileManipulationActionCreateData) {
+    const { path, content, overwrite = false } = actionData;
+
+    const interpolatedPath = this.interpolate(path);
+    const absolutePath = this.context.projectDirectory.resolve(interpolatedPath);
+    let overwritten = false;
+
+    if (existsSync(absolutePath)) {
+      if (overwrite) {
+        overwritten = true;
+      } else {
+        throw new CodxError(`File "${absolutePath}" already exists and the "overwrite" option is not enabled.`);
+      }
+    }
+
+    const parentPath = dirname(absolutePath);
+    if (!existsSync(parentPath)) {
+      mkdirSync(parentPath, { recursive: true });
+    }
+
+    const interpolatedContent = this.interpolate(content ?? '');
+
+    // Write the content to the file
+    writeFileSync(absolutePath, interpolatedContent);
+    this.logger.success(`File created successfully: ${absolutePath}`);
+
+    return {
+      path: absolutePath,
+      overwritten,
+    };
+  }
+
+  /**
+   * Prepends content to the beginning of a file
+   * @param {FileManipulationActionPrependData} actionData Action data
+   */
+  private executePrepend(actionData: FileManipulationActionPrependData) {
+    const { path, content } = actionData;
+
+    const interpolatedPath = this.interpolate(path);
+    const absolutePath = this.context.projectDirectory.resolve(interpolatedPath);
+
+    if (!existsSync(absolutePath)) {
+      throw new CodxError(`File "${absolutePath}" does not exist.`);
+    }
+
+    const interpolatedContent = this.interpolate(content);
+    const existingContent = readFileSync(absolutePath, 'utf8');
+    const newContent = interpolatedContent + existingContent;
+
+    writeFileSync(absolutePath, newContent);
+    this.logger.success(`Content prepended successfully to: ${absolutePath}`);
+
+    return {
+      path: absolutePath,
+      prepended: true,
+    };
+  }
+
+  /**
+   * Updates content in a file using a regex pattern
+   * @param {FileManipulationActionUpdateData} actionData Action data
+   */
+  private executeUpdate(actionData: FileManipulationActionUpdateData) {
+    const { path, pattern, content } = actionData;
+
+    const interpolatedPath = this.interpolate(path);
+    const absolutePath = this.context.projectDirectory.resolve(interpolatedPath);
+
+    if (!existsSync(absolutePath)) {
+      throw new CodxError(`File "${absolutePath}" does not exist.`);
+    }
+
+    const interpolatedPattern = this.interpolate(pattern);
+    const interpolatedContent = this.interpolate(content);
+    const existingContent = readFileSync(absolutePath, 'utf8');
+
+    try {
+      const regex = new RegExp(interpolatedPattern, 'g');
+      const newContent = existingContent.replace(regex, interpolatedContent);
+
+      if (newContent === existingContent) {
+        this.logger.warning(`Pattern "${interpolatedPattern}" not found in file: ${absolutePath}`);
+
+        return {
+          path: absolutePath,
+          updated: false,
+        };
+      }
+
+      writeFileSync(absolutePath, newContent);
+      this.logger.success(`Content updated successfully in: ${absolutePath}`);
+
+      return {
+        path: absolutePath,
+        updated: true,
+      };
+    } catch (error) {
+      throw new CodxError(`Invalid regular expression pattern: ${interpolatedPattern}`, error);
+    }
+  }
+}

--- a/src/actions/fileSystem/FileSystemAction.schema.ts
+++ b/src/actions/fileSystem/FileSystemAction.schema.ts
@@ -13,19 +13,6 @@ export const FileSystemActionCopyDataSchema = z
 
 export type FileSystemActionCopyData = z.infer<typeof FileSystemActionCopyDataSchema>;
 
-// create
-export const FileSystemActionCreateDataSchema = z
-  .object({
-    type: z.literal('fileSystem'),
-    operation: z.literal('create'),
-    path: z.string(),
-    content: z.string().optional(),
-    overwrite: z.boolean().optional().default(false),
-  })
-  .describe('FileSystemActionCreateDataSchema');
-
-export type FileSystemActionCreateData = z.infer<typeof FileSystemActionCreateDataSchema>;
-
 // delete
 export const FileSystemActionDeleteDataSchema = z
   .object({
@@ -75,7 +62,6 @@ export type FileSystemActionMoveData = z.infer<typeof FileSystemActionMoveDataSc
 export const FileSystemActionDataSchema = z
   .union([
     FileSystemActionCopyDataSchema,
-    FileSystemActionCreateDataSchema,
     FileSystemActionDeleteDataSchema,
     FileSystemActionExistsDataSchema,
     FileSystemActionMkdirDataSchema,

--- a/src/actions/fileSystem/FileSystemAction.spec.ts
+++ b/src/actions/fileSystem/FileSystemAction.spec.ts
@@ -1,7 +1,6 @@
 import { FileSystemAction } from '@/actions/fileSystem/FileSystemAction';
 import {
   FileSystemActionCopyData,
-  FileSystemActionCreateData,
   FileSystemActionData,
   FileSystemActionMoveData,
 } from '@/actions/fileSystem/FileSystemAction.schema';
@@ -69,56 +68,6 @@ describe('FileSystemAction', () => {
   afterEach(() => {
     mockFsCleaner();
     mock.restore();
-  });
-
-  describe('Operation CREATE', () => {
-    test('should create a file with content', async () => {
-      // Mock file does not exist
-      (existsSync as any).mockReturnValue(false);
-
-      const actionData = {
-        type: 'fileSystem',
-        operation: 'create',
-        path: mockFilePath,
-        content: mockContent,
-      } as FileSystemActionCreateData;
-
-      await action.execute(actionData);
-
-      expect(writeFileSync).toHaveBeenCalledWith(mockAbsolutePath, mockInterpolatedContent);
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('File created successfully'));
-    });
-
-    test('should throw error when file exists and overwrite option is not enabled', async () => {
-      (existsSync as any).mockReturnValue(true);
-
-      const actionData = {
-        type: 'fileSystem',
-        operation: 'create',
-        path: mockFilePath,
-        content: mockContent,
-      } as FileSystemActionData;
-
-      expect(action.execute(actionData)).rejects.toThrow(CodxError);
-      expect(action.execute(actionData)).rejects.toThrow('already exists and the "overwrite" option is not enabled');
-    });
-
-    test('should create a file with content when file exists and overwrite option is enabled', async () => {
-      (existsSync as any).mockReturnValue(true);
-
-      const actionData = {
-        type: 'fileSystem',
-        operation: 'create',
-        path: mockFilePath,
-        content: mockContent,
-        overwrite: true,
-      } as FileSystemActionData;
-
-      await action.execute(actionData);
-
-      expect(writeFileSync).toHaveBeenCalledWith(mockAbsolutePath, mockInterpolatedContent);
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('File created successfully'));
-    });
   });
 
   describe('Operation DELETE', () => {

--- a/src/actions/fileSystem/FileSystemAction.ts
+++ b/src/actions/fileSystem/FileSystemAction.ts
@@ -1,7 +1,6 @@
 import { BaseAction } from '@/actions/BaseAction';
 import {
   FileSystemActionCopyData,
-  FileSystemActionCreateData,
   FileSystemActionData,
   FileSystemActionDeleteData,
   FileSystemActionExistsData,
@@ -9,7 +8,7 @@ import {
   FileSystemActionMoveData,
 } from '@/actions/fileSystem/FileSystemAction.schema';
 import { CodxError } from '@/core/CodxError';
-import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 /**
@@ -26,9 +25,6 @@ export class FileSystemAction extends BaseAction {
     switch (operation) {
       case 'copy':
         return this.executeCopy(actionData);
-
-      case 'create':
-        return this.executeCreate(actionData);
 
       case 'delete':
         return this.executeDelete(actionData);
@@ -135,39 +131,6 @@ export class FileSystemAction extends BaseAction {
     return {
       source: sourcePath,
       destination: destinationPath,
-      overwritten,
-    };
-  }
-
-  /**
-   * Creates a file with the specified content
-   * @param {FileSystemActionCreateData} actionData Action data
-   */
-  private executeCreate(actionData: FileSystemActionCreateData) {
-    const { path, content, overwrite = false } = actionData;
-
-    const interpolatedPath = this.interpolate(path);
-    const absolutePath = this.context.projectDirectory.resolve(interpolatedPath);
-    let overwritten = false;
-
-    if (existsSync(absolutePath)) {
-      if (overwrite) {
-        overwritten = true;
-      } else {
-        throw new CodxError(`File "${absolutePath}" already exists and the "overwrite" option is not enabled.`);
-      }
-    }
-
-    this.createParentDirIfNeeded(absolutePath);
-
-    const interpolatedContent = this.interpolate(content ?? '');
-
-    // Write the content to the file
-    writeFileSync(absolutePath, interpolatedContent);
-    this.logger.success(`File created successfully: ${absolutePath}`);
-
-    return {
-      path: absolutePath,
       overwritten,
     };
   }


### PR DESCRIPTION
Introduce the `fileManipulation` action with full support for operations like `create`, `prepend`, `append`, and `update`. Documentation is provided in English and French to explain usage, parameters, and best practices.